### PR TITLE
rakeタスク内のロジックをmodelに移した

### DIFF
--- a/app/models/lottery.rb
+++ b/app/models/lottery.rb
@@ -10,7 +10,11 @@ class Lottery < ApplicationRecord
   validates :prizes, presence: true
   scope :closed_lottery, -> { where('deadline = ?', Time.zone.today.ago(1.day).to_date) }
 
-  def run
+  def self.run
+    Lottery.closed_lottery.each(&:execute)
+  end
+
+  def execute
     entry_list = entries.to_a
 
     prizes.each do |prize|

--- a/lib/tasks/execute_lottery.rake
+++ b/lib/tasks/execute_lottery.rake
@@ -3,6 +3,6 @@
 namespace :lottery do
   desc 'lottery_in_midnight'
   task execute_lottery: :environment do
-    Lottery.closed_lottery.find_each(&:run)
+    Lottery.run
   end
 end

--- a/spec/helpers/lotteries_helper_spec.rb
+++ b/spec/helpers/lotteries_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe LotteriesHelper, type: :helper do
   let(:lottery_executed) { create(:lottery, deadline: Time.zone.yesterday) }
 
   it 'lottery_executed?' do
-    lottery_executed.run
+    lottery_executed.execute
     expect(lottery_executed?(lottery_executed)).to eq true
     expect(lottery_executed?(lottery)).to eq false
   end

--- a/spec/models/lottery_spec.rb
+++ b/spec/models/lottery_spec.rb
@@ -7,17 +7,16 @@ RSpec.describe Lottery, type: :model do
 
   describe 'run' do
     let!(:closed_lottery) { create(:lottery, deadline: Time.zone.yesterday) }
-    let!(:open_lottery) { create(:lottery, deadline: Time.zone.today) }    
+    let!(:open_lottery) { create(:lottery, deadline: Time.zone.today) }
 
     it 'lottery executed' do
-      Lottery.run
+      described_class.run
       expect(lottery_executed?(closed_lottery)).to eq true
     end
 
     it 'not lottery executed' do
-      Lottery.run
+      described_class.run
       expect(lottery_executed?(open_lottery)).to eq false
     end
-
   end
 end

--- a/spec/models/lottery_spec.rb
+++ b/spec/models/lottery_spec.rb
@@ -8,17 +8,22 @@ RSpec.describe Lottery, type: :model do
   describe 'run' do
     let!(:closed_lottery) { create(:lottery, deadline: Time.zone.yesterday) }
     let!(:open_lottery) { create(:lottery, deadline: Time.zone.today) }
+    let!(:closed_lottery_2days_ago) { create(:lottery, deadline: Time.zone.today.ago(2.days)) }
 
     before do
       described_class.run
     end
 
     it 'lottery executed' do
-      expect(lottery_executed?(closed_lottery)).to eq true
+      expect(lottery_executed?(closed_lottery)).to be_truthy
     end
 
-    it 'not lottery executed' do
-      expect(lottery_executed?(open_lottery)).to eq false
+    it 'open lottery do not executed' do
+      expect(lottery_executed?(open_lottery)).to be_falsey
+    end
+
+    it 'closed lottery 2days ago do not executed' do
+      expect(lottery_executed?(closed_lottery_2days_ago)).to be_falsey
     end
   end
 end

--- a/spec/models/lottery_spec.rb
+++ b/spec/models/lottery_spec.rb
@@ -9,13 +9,15 @@ RSpec.describe Lottery, type: :model do
     let!(:closed_lottery) { create(:lottery, deadline: Time.zone.yesterday) }
     let!(:open_lottery) { create(:lottery, deadline: Time.zone.today) }
 
-    it 'lottery executed' do
+    before do
       described_class.run
+    end
+
+    it 'lottery executed' do
       expect(lottery_executed?(closed_lottery)).to eq true
     end
 
     it 'not lottery executed' do
-      described_class.run
       expect(lottery_executed?(open_lottery)).to eq false
     end
   end

--- a/spec/models/lottery_spec.rb
+++ b/spec/models/lottery_spec.rb
@@ -3,5 +3,21 @@
 require 'rails_helper'
 
 RSpec.describe Lottery, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  include LotteriesHelper
+
+  describe 'run' do
+    let!(:closed_lottery) { create(:lottery, deadline: Time.zone.yesterday) }
+    let!(:open_lottery) { create(:lottery, deadline: Time.zone.today) }    
+
+    it 'lottery executed' do
+      Lottery.run
+      expect(lottery_executed?(closed_lottery)).to eq true
+    end
+
+    it 'not lottery executed' do
+      Lottery.run
+      expect(lottery_executed?(open_lottery)).to eq false
+    end
+
+  end
 end

--- a/spec/system/lottery_spec.rb
+++ b/spec/system/lottery_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Lottery, type: :system do
   end
 
   it 'display winners' do
-    lottery_executed.run
+    lottery_executed.execute
     sign_in user
     visit lottery_path(lottery_executed)
 


### PR DESCRIPTION
- #122 

rakeタスクの中にロジックを書いていたためテストがしにくかったことに加え、ビジネスロジックはmodelに書くべきなのでrakeタスク内はメソッドを呼び出すだけに変更しました。
また、それに伴いテストも追加しました。